### PR TITLE
Repository fix

### DIFF
--- a/src/Chamilo/Core/Repository/ContentObject/AssessmentMatchingQuestion/composer.json
+++ b/src/Chamilo/Core/Repository/ContentObject/AssessmentMatchingQuestion/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "cosnics": {
-            "name": "Matching Question",
+            "name": "Assessment Matching Question",
             "context": "Chamilo\\Core\\Repository\\ContentObject\\AssessmentMatchingQuestion",
             "type": "Chamilo\\Core\\Repository\\ContentObject",
             "category": "Assessment",

--- a/src/Chamilo/Core/Repository/ContentObject/FillInBlanksQuestion/composer.json
+++ b/src/Chamilo/Core/Repository/ContentObject/FillInBlanksQuestion/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "cosnics": {
-            "name": "Fill-in-the-blanks Question",
+            "name": "Fill In Blanks Question",
             "context": "Chamilo\\Core\\Repository\\ContentObject\\FillInBlanksQuestion",
             "type": "Chamilo\\Core\\Repository\\ContentObject",
             "category": "Assessment",

--- a/src/Chamilo/Core/Repository/ContentObject/RssFeed/composer.json
+++ b/src/Chamilo/Core/Repository/ContentObject/RssFeed/composer.json
@@ -25,7 +25,7 @@
     },
     "extra": {
         "cosnics": {
-            "name": "RSS Feed",
+            "name": "Rss Feed",
             "context": "Chamilo\\Core\\Repository\\ContentObject\\RssFeed",
             "type": "Chamilo\\Core\\Repository\\ContentObject",
             "category": "News",

--- a/src/Chamilo/Core/Repository/ContentObject/Youtube/composer.json
+++ b/src/Chamilo/Core/Repository/ContentObject/Youtube/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "cosnics": {
-            "name": "YouTube Video",
+            "name": "Youtube",
             "context": "Chamilo\\Core\\Repository\\ContentObject\\Youtube",
             "type": "Chamilo\\Core\\Repository\\ContentObject",
             "category": "Media",


### PR DESCRIPTION
When the cache is buildup, incorrect CO classes are registered.
Therefore the installer is filling the database incorrectly.
Result: Repository crash because some CO classes are not found.

PHP Fatal error:  Uncaught ReflectionException: Class Chamilo\\Core\\Repository\\ContentObject\\FillInBlanksQuestion\\Storage\\DataClass\\FillInTheBlanksQuestion does not exist in .......